### PR TITLE
Validation improvements

### DIFF
--- a/src/JEM-schema.json
+++ b/src/JEM-schema.json
@@ -1,0 +1,299 @@
+{
+    "type": "object",
+    "title":"JSON Electrophysiology Metadata (JEM)",
+    "properties": {
+        "formVersion": {
+            "type":"string",
+            "title":"Version",
+            "readonly":true
+        },
+        "rigOperator": {
+            "type": "string",
+            "title": "Researcher",
+            "enum":["nataliag", "rene", "djai", "christina", "ayoub", "aarono", "briank", "brianle", "dijonh", "gasparo", "huibm", "jonathant", "kristenh", "lindsayn", "lisak", "ramr", "rustym", "davidre"],
+            "required":true
+        },
+        "rigNumber": {
+            "type":"string",
+            "title":"Rig #",
+            "enum":["1","2","3","4","5","6","7","8", "BRL", "HCT1", "HCT2", "HCT3"],
+            "required":true
+        },
+        "date":{
+            "format":"date",
+            "title":"Slice on Rig Date/Time",
+            "required":true
+        },
+        "limsSpecName": {
+            "type": "string",
+            "title":"Slice ID",
+            "required":true
+        },
+        "acsfProductionDate":{
+            "format":"date",
+            "title":"ACSF Date",
+            "required":true
+        },
+        "blankFillDate":{
+            "format":"date",
+            "title":"Blank Fill Date",
+            "enum":["2018-07-10"],
+            "required":true
+        },
+        "internalFillDate":{
+            "format":"date",
+            "title":"Internal Fill Date",
+            "required":true
+        },
+        "flipped": {
+            "type":"string",
+            "title":"Is slice flipped?",
+            "enum":["Yes","No"],
+            "required":true
+        },
+        "sliceQuality":{
+            "type":"string",
+            "enum": ["Good", "Damaged", "Uneven Thickness", "'Wave of Death'"],
+            "default":[],
+            "required":true
+        },
+        "sliceNotes":{
+            "type":"string",
+            "format":"string",
+            "title":"Extra Slice Notes",
+            "required":false
+        },
+        "pipettes":{
+            "type":"array",
+            "items":{
+                "title":"Patch-Seq Pipette",
+                "type":"object",
+                "properties":{
+                    "approach": {
+                        "type":"object",
+                        "title": "Approach Info",
+                        "properties": {
+                            "sliceHealth":{
+                                "type":"string",
+                                "title": "Slice Health",
+                                "enum":["1","2","3","4","5"],
+                                "required":true
+                            },
+                            "cellHealth":{
+                                "type":"string",
+                                "title": "Cell Health",
+                                "enum":["1","2","3","4","5"],
+                                "required":true
+                            },
+                            "creCell": {
+                                "type":"string",
+                                "title":"Cre Status",
+                                "enum":["Cre+","Cre-","None"],
+                                "required":true
+                            },
+                            "pilotName":{
+                                "type":"string",
+                                "title":"Pilot Name",
+                                "default": "None",
+                                "enum": ["None", "Tissue_Touch", "Electroporation", "Non_Human_Primate_LGN", "Nucleated Patch - Retraction Pressure"],
+                                "required":true
+                            },
+                            "pilotTest01":{
+                                "type":"string",
+                                "title":"Pilot Details",
+                                "enum":["Standard (~80 mbar)", "Mid-Range (~65 mbar)", "Low (~50 mbar)", "Minimal (~25 mbar)"],
+                                "default":"",
+                                "dependencies":"pilotName",
+                                "required":false
+                            },
+                             "pilotTest04":{
+                               "type":"string",
+                                "title":"Pilot Details",
+                                "dependencies":"pilotName",
+                                "required":false
+                            }
+                        }
+                    },
+/*                                            "pipetteSpecName": {
+                                "type": "string",
+                                "title":"Pipette Specimen ID",
+                                "required":true
+                    },*/
+                    "recording":{
+                        "type":"object",
+                        "title":"Recording Info",
+                        "properties": {
+                            "timeStart": {
+                                "format":"time",
+                                "title":"Approach Start",
+                                "required":true
+                            },
+                            "pipetteR":{
+                                "format":"number",
+                                "minimum":0,
+                                "title":"Pipette R",
+                                "required":true
+                            },
+                            "timeWholeCellStart":{
+                                "format":"time",
+                                "title":"Whole Cell Start",
+                                "required":true
+                            },
+                            "humanCellTypePrediction":{
+                                "type":"string",
+                                "title":"Cell Type Prediction (for Human Neurons)",
+                                "enum":["Unknown", "Pyramidal", "FS Interneuron", "Spindle Shaped", "Unknown Interneuron"],
+                                "required":false
+                            }
+                        }
+                    },
+                    "status":{
+                        "type":"string",
+                        "title":"Was recording successful?",
+                        "enum":["SUCCESS", "FAILURE"],
+                        "default":[],
+                        "required":true
+                    },
+                    "failureNotes":{
+                        "type":"string",
+                        "enum":["Seal Failed","Unstable Seal","Breakin Failed","Access Resistance Out of Range","Vrest Out of Range", "'Wave of Death'", "Other"],
+                        "default":[],
+                        "dependencies":"status",
+                        "required":true
+                    },
+                    "freeFailureNotes":{
+                        "type":"string",
+                        "title":"Extra Failure Notes",
+                        "default":[],
+                        "dependencies":"status",
+                        "required":false
+                    },
+                    "successNotes":{
+                        "type":"string",
+                        "enum": ["Patch/Cell Unstable", "Patch Became Leaky", "Access Resistance Increased", "Cell Depolarized", "Cell Hyperpolarized", "Blowout Voltage Out of Range", "Rheobase Changed", "Ended After C1", "'Wave of Death'", "Training/Practice", "Rig/Software Problems"],
+                        "default":[],
+                        "dependencies":"status",
+                        "required":false
+                    },
+                    "qcNotes":{
+                        "type":"string",
+                        "title":"QC Notes",
+                        "dependencies":"status",
+                        "required":false
+                    },
+                    "badSweeps":{
+                        "type":"string",
+                        "title":"Bad Sweeps",
+                        "dependencies":"status",
+                        "required":false
+                    },
+                    "extraction":{
+                        "type":"object",
+                        "title":"Extraction Info",
+                        "dependencies":"status",
+                        "properties":{
+                            "pressureApplied":{
+                                "type":"number",
+                                "title":"Extraction Pressure",
+                                "maximum":0,
+                                "required":true
+                            },
+                            "retractionPressureApplied":{
+                                "type":"number",
+                                "title":"Retraction Pressure",
+                                "maximum":0,
+                                "required":true
+                            },
+                            "timeExtractionStart":{
+                                "format":"time",
+                                "title":"Extraction Start",
+                                "required":true
+                            },
+                            "timeExtractionEnd":{
+                                "format":"time",
+                                "title":"Extraction End",
+                                "required":true
+                            },
+                            "timeRetractionEnd":{
+                                "format":"time",
+                                "title":"Retraction End",
+                                "required":true
+                            },
+                            "postPatch":{
+                                "type":"string",
+                                "title":"Post Patch State",
+                                "enum":["nucleus_present", "nucleus_absent", "entire_cell"],
+                                "default":[],
+                                "required":true
+                            },
+                            "endPipetteR":{
+                                "format":"number",
+                                "minimum":0,
+                                "title":"Post Patch Pipette R",
+                                "required":true
+                            },
+                            "nucleus": {
+                                "type":"string",
+                                "title":"Nucleus sucked in?",
+                                "enum":["intentionally", "not_intentionally", "no"],
+                                "default":[],
+                                "required":false
+                            },
+                            "tubeID":{
+                                "type":"string",
+                                "title":"Patched Cell Container",
+                                "required":true
+                            },
+                            "extractionNotes": {
+                                "type": "string",
+                                "title": "Extra Extraction Notes"
+                            },
+                            "extractionObservations":{
+                                "type":"string",
+                                "title": "Cell Assessment",
+                                "enum": ["Fluorescence in Pipette", "Cell Dimmed", "Cell Swelled", "Cell Shrunk", "Too Deep","Cell Disappeared"],
+                                "default": [],
+                                "required":false
+                            },
+                            "sampleObservations":{
+                                "type":"string",
+                                "title":"Sample Assessment",
+                                "enum":["No Bubbles", "Small Bubbles", "Medium Bubbles", "Large Bubbles", "Solution in Pipette Shank"],
+                                "default":[],
+                                "required":false
+                            }
+                        }
+                    },
+                    "depth": {
+                        "format":"number",
+                        "title":"Cell Depth",
+                        "required":true
+                    },
+                    "autoRoi":{
+                        "type":"string",
+                        "title": "ROI (Pinning Tool)",
+                        "required":false,
+                        "default":"None"
+                    },
+                    "manualRoi":{
+                        "type":"string",
+                        "title": "ROI (Manual Entry)",
+                        "required":true,
+                        "dependencies":"autoRoi"
+                    }
+                }
+            }
+        }
+    },
+    "dependencies": {
+        "manualRoi":["autoRoi"],
+        "pilotTest01":["pilotName"],
+        "pilotTest04":["pilotName"],
+        "failureNotes":["status"],
+        "freeFailureNotes":["status"],
+        "successNotes":["status"],
+        "qcNotes":["status"],
+        "badSweeps":["status"],
+        "extraction":["status"]
+        }
+}

--- a/src/JEM.html
+++ b/src/JEM.html
@@ -22,11 +22,11 @@
             <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
      
             <!-- handlebars -->
-            <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.0.11/handlebars.js"></script>
+            <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.0.11/handlebars.js"></script>
      
             <!-- alpaca -->
-            <link type="text/css" href="http://code.cloudcms.com/alpaca/1.5.23/bootstrap/alpaca.min.css" rel="stylesheet"/>
-            <script type="text/javascript" src="http://code.cloudcms.com/alpaca/1.5.23/bootstrap/alpaca.min.js"></script>
+            <link type="text/css" href="https://code.cloudcms.com/alpaca/1.5.23/bootstrap/alpaca.min.css" rel="stylesheet"/>
+            <script type="text/javascript" src="https://code.cloudcms.com/alpaca/1.5.23/bootstrap/alpaca.min.js"></script>
 
             <!-- fileSaver -->
             <script type="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/1.3.3/FileSaver.min.js"></script>
@@ -48,12 +48,275 @@
             }
             document.onkeypress = stopRKey;
             </script> 
+            
+            <style>
+                .menu-container {
+                    position: fixed;
+                    top: 5px;
+                    right: 10px;
+                    z-index: 1;
+                    height: 50px;
+                }
+                .menu-container button {
+                    margin: 0px 5px 0px 5px;
+                    width: 150px;
+                    height: 50px;
+                }
+                
+                /* Hide the load file input and reset buttons that we access programmatically */
+                input[type=file], button[type=reset] {
+                    display: none;
+                }
+                
+                .invisible {
+                    display: none;
+                }
+                
+                #saveJsonButton {
+                    float: left;
+                }
+                
+                #loadJsonButton {
+                    float: right;
+                }
+            </style>
         
-        <head>
+        </head>
         <body>
+            <form>
+                <div class="menu-container">
+                    <button id="saveJsonButton" class="btn-lg btn-success" type="button" onclick="saveJsonClick()">
+                        <div id="saveJsonText">Save JSON</div>
+                        <div id="saveJsonLoading" class="invisible">
+                            <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+                                 width="24px" height="30px" viewBox="0 0 24 30" style="enable-background:new 0 0 50 50;" xml:space="preserve">
+                                <rect x="0" y="10" width="4" height="10" fill="#333" opacity="0.2">
+                                  <animate attributeName="opacity" attributeType="XML" values="0.2; 1; .2" begin="0s" dur="0.6s" repeatCount="indefinite" />
+                                  <animate attributeName="height" attributeType="XML" values="10; 20; 10" begin="0s" dur="0.6s" repeatCount="indefinite" />
+                                  <animate attributeName="y" attributeType="XML" values="10; 5; 10" begin="0s" dur="0.6s" repeatCount="indefinite" />
+                                </rect>
+                                <rect x="8" y="10" width="4" height="10" fill="#333"  opacity="0.2">
+                                  <animate attributeName="opacity" attributeType="XML" values="0.2; 1; .2" begin="0.15s" dur="0.6s" repeatCount="indefinite" />
+                                  <animate attributeName="height" attributeType="XML" values="10; 20; 10" begin="0.15s" dur="0.6s" repeatCount="indefinite" />
+                                  <animate attributeName="y" attributeType="XML" values="10; 5; 10" begin="0.15s" dur="0.6s" repeatCount="indefinite" />
+                                </rect>
+                                <rect x="16" y="10" width="4" height="10" fill="#333"  opacity="0.2">
+                                  <animate attributeName="opacity" attributeType="XML" values="0.2; 1; .2" begin="0.3s" dur="0.6s" repeatCount="indefinite" />
+                                  <animate attributeName="height" attributeType="XML" values="10; 20; 10" begin="0.3s" dur="0.6s" repeatCount="indefinite" />
+                                  <animate attributeName="y" attributeType="XML" values="10; 5; 10" begin="0.3s" dur="0.6s" repeatCount="indefinite" />
+                                </rect>
+                            </svg>
+                        </div>
+                    </button>
+                    <button id="loadJsonButton" class="btn-lg btn-info" type="button" onclick="loadJsonClick()">
+                        <div id="loadJsonText">Load JSON</div>
+                        <div id="loadJsonLoading" class="invisible">
+                            <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+                                 width="24px" height="30px" viewBox="0 0 24 30" style="enable-background:new 0 0 50 50;" xml:space="preserve">
+                                <rect x="0" y="10" width="4" height="10" fill="#333" opacity="0.2">
+                                  <animate attributeName="opacity" attributeType="XML" values="0.2; 1; .2" begin="0s" dur="0.6s" repeatCount="indefinite" />
+                                  <animate attributeName="height" attributeType="XML" values="10; 20; 10" begin="0s" dur="0.6s" repeatCount="indefinite" />
+                                  <animate attributeName="y" attributeType="XML" values="10; 5; 10" begin="0s" dur="0.6s" repeatCount="indefinite" />
+                                </rect>
+                                <rect x="8" y="10" width="4" height="10" fill="#333"  opacity="0.2">
+                                  <animate attributeName="opacity" attributeType="XML" values="0.2; 1; .2" begin="0.15s" dur="0.6s" repeatCount="indefinite" />
+                                  <animate attributeName="height" attributeType="XML" values="10; 20; 10" begin="0.15s" dur="0.6s" repeatCount="indefinite" />
+                                  <animate attributeName="y" attributeType="XML" values="10; 5; 10" begin="0.15s" dur="0.6s" repeatCount="indefinite" />
+                                </rect>
+                                <rect x="16" y="10" width="4" height="10" fill="#333"  opacity="0.2">
+                                  <animate attributeName="opacity" attributeType="XML" values="0.2; 1; .2" begin="0.3s" dur="0.6s" repeatCount="indefinite" />
+                                  <animate attributeName="height" attributeType="XML" values="10; 20; 10" begin="0.3s" dur="0.6s" repeatCount="indefinite" />
+                                  <animate attributeName="y" attributeType="XML" values="10; 5; 10" begin="0.3s" dur="0.6s" repeatCount="indefinite" />
+                                </rect>
+                            </svg>
+                        </div>
+                    </button>
+                    <input id="loadJsonInputHidden" type="file" accept=".json" onchange="loadJsonFile(event)"/>
+                </div>
+            </form>
             <div id="form"></div>
             <script src = "https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/1.3.3/FileSaver.min.js" async = ""></script>
             <script type="text/javascript">
+                // Called when the user clicks the "Load JSON" button.
+                // We hide the unattractive default file input type and access it programmatically.
+                function loadJsonClick() {
+                    $("#loadJsonInputHidden").click();
+                }
+                
+                // Called when the user selects a file to load.
+                function loadJsonFile(selectFileEvent) {
+                    var button = selectFileEvent.target;
+                    if (button && button.files && button.files.length > 0) {
+                        var file = button.files[0];
+                        var fileName = file.name;
+                        var reader = new FileReader();
+                        reader.onload = function(loadFinishEvent) {
+                            var jsonData = JSON.parse(loadFinishEvent.target.result);
+                            var formElement = $("#form");
+                            var form = formElement.alpaca("get");
+                            
+                            setLoadButtonState(true);
+                            
+                            // Blank out the form, try to load the data, and if it's invalid, blank it again.
+                            resetForm(function() {
+                                // Alpaca does not provide a callback for when it finishes filling in/creating fields.
+                                // So we check every 1.0 seconds to see if there's been more elements added to the form.
+                                var childCount = 0;
+                                form.setValue(jsonData);
+                                
+                                var childChecker = setInterval(function() {
+                                    var newCount = formElement.find("*").length;
+                                    
+                                    if (childCount != newCount) {
+                                        childCount = newCount;
+                                    } else {
+                                        clearInterval(childChecker);
+                                        
+                                        form.top().refreshValidationState(true, function() {
+                                            if (!form.isValid(true)) {
+                                                var invalidFieldInfo = findInvalidFields();
+                                                if (invalidFieldInfo.fieldNames) {
+                                                    alert(fileName + " is not a valid Json file.\n"
+                                                            + "The following fields are invalid:\n"
+                                                            + "-----\n"
+                                                            + invalidFieldInfo.fieldNames.join("\n"));
+                                                }
+                                                
+                                                if (invalidFieldInfo.focusInput) {
+                                                    invalidFieldInfo.focusInput.focus();
+                                                }
+                                            }
+                                            
+                                            setLoadButtonState(false);
+                                        });
+                                    }
+                                }, 1000);
+                            });
+                        }
+                        
+                        reader.readAsText(file);
+                    }
+                }
+                
+                // Called when user clicks the "Save JSON" button.
+                function saveJsonClick() {
+                    var form = $("#form").alpaca('get');
+                    
+                    setSaveButtonState(true);
+                    
+                    form.top().refreshValidationState(true, function() {
+                        if (form.isValid(true)) {
+                            var val = form.getValue();
+                            var myjson = JSON.stringify(val, null, "  ");
+                            var blob = new Blob([myjson], {type: "application/json"});
+                            if (window.saveAs) {
+                                specFileName = val.limsSpecName + ".PS.json";
+                                window.saveAs(blob, specFileName);
+                                alert("Successfully saved " + specFileName + "\n" 
+                                        + "Metadata Values: " + myjson);
+                            }else{
+                                alert("The saveAs feature is not supported by your browser.");
+                            }
+                        } else {
+                            var invalidFieldInfo = findInvalidFields();
+                            if (invalidFieldInfo.fieldNames) {
+                                alert("Cannot save form.\n"
+                                        + "The following fields are invalid:\n"
+                                        + "-----\n"
+                                        + invalidFieldInfo.fieldNames.join("\n"));
+                            }
+                            
+                            if (invalidFieldInfo.focusInput) {
+                                invalidFieldInfo.focusInput.focus();
+                            }
+                        }
+                        
+                        setSaveButtonState(false);
+                    });
+                }
+                
+                // Collect all lowest-level invalid elements, return their labels and the first input (for focus)
+                // Returns an object like {"fieldNames": [...], "focusElement": domObj}
+                function findInvalidFields() {                    
+                    var allInvalidNames = [];
+                    var focusElement = null;
+                    var allInvalidElements = $(".alpaca-invalid");
+                    allInvalidElements.each(function(index, invalidElement) {
+                        if (!$(invalidElement).find(".alpaca-invalid").length) {
+                            allInvalidNames.push($(invalidElement).find("label").eq(0).text());
+                            
+                            if (!focusElement) {
+                                focusElement = $(invalidElement).find(":input").eq(0);
+                            }
+                        }
+                        
+                        return true;
+                    });
+                    
+                    return {"fieldNames": allInvalidNames, "focusInput": focusElement};
+                }
+                
+                // Help Alpaca reset the form more cleanly.
+                function resetForm(finishCallback) {
+                    var form = $("#form").alpaca("get");
+                    
+                    // Empty the pipette array.
+                    var pipettes = form.top().getControlByPath("pipettes");
+                    var pipettesRemaining = pipettes.getSize();
+                    removePipettes(pipettes, pipettesRemaining, function() {
+                        // Reset the rest of the data.
+                        $("button[type='reset']").click();
+                        if (finishCallback) {
+                            finishCallback();
+                        }
+                    });
+                }
+                
+                // A function that uses recursive callbacks to remove pipettes one at a time.
+                function removePipettes(pipettes, pipettesRemaining, finishCallback) {
+                    if (pipettesRemaining > 0) {
+                        pipettes.handleActionBarRemoveItemClick(0, function() {
+                            removePipettes(pipettes, pipettesRemaining - 1, finishCallback);
+                        });
+                    } else if (finishCallback) {
+                        finishCallback();
+                    }
+                }
+                
+                // Finds a text field inside the given alpaca field and makes it read-only.
+                // Use by calling makeTextFieldReadOnly(this) in a field's "ready" function.
+                function makeTextFieldReadOnly(alpacaField) {
+                    var textField = $(alpacaField.field).find("[type='text']");
+                    if (textField && textField.length) {
+                        textField.prop("readonly", "readonly");
+                    }
+                }
+                
+                // Sets the "Save JSON" button into and out of its "loading mode"
+                function setSaveButtonState(isLoading) {
+                    setButtonState("#saveJsonButton", "#loadJsonButton", "#saveJsonText", "#saveJsonLoading", "btn-success", isLoading);
+                }
+                
+                // Sets the "Load JSON" button into and out of its "loading mode"
+                function setLoadButtonState(isLoading) {
+                    setButtonState("#loadJsonButton", "#saveJsonButton", "#loadJsonText", "#loadJsonLoading", "btn-info", isLoading);
+                }
+                
+                // Helper function for set****ButonState functions.
+                function setButtonState(buttonId, otherButtonId, buttonTextId, buttonLoadingId, successClass, isLoading) {
+                    if (isLoading) {
+                        $(buttonId).attr("disabled", "disabled").removeClass(successClass).addClass("btn-warning");
+                        $(otherButtonId).attr("disabled", "disabled");
+                        $(buttonTextId).addClass("invisible");
+                        $(buttonLoadingId).removeClass("invisible");
+                    } else {
+                        $(buttonId).removeAttr("disabled").removeClass("btn-warning").addClass(successClass);
+                        $(otherButtonId).removeAttr("disabled");
+                        $(buttonTextId).removeClass("invisible");
+                        $(buttonLoadingId).addClass("invisible");
+                    }
+                }
+            
                 $(document).ready(function() {
                     $("#form").alpaca({
                         "schema": {
@@ -95,6 +358,7 @@
                                 "blankFillDate":{
                                     "format":"date",
                                     "title":"Blank Fill Date",
+                                    "enum":["2018-07-10"],
                                     "required":true
                                 },
                                 "internalFillDate":{
@@ -542,21 +806,18 @@
                                     "hideInitValidationError":true
                                 },  
                                 "blankFillDate": {
-                                    "type":"date",
-                                    "fieldClass":"col-md-2",
-                                    "picker": {
-                                        "format":"YYYY-MM-DD",
-                                        "showClose":true,
-                                        "inline":false,
-                                        "tooltips": {
-                                            today: "Go to today"
-                                        },
-                                        "useCurrent":true
-                                    },
-                                    "manualEntry":false,
+                                    "type":"select",
+                                    "fieldClass":"dropdown-content col-md-2",
+                                    "helper":[],
+                                    "hideNone":false,
+                                    "noneLabel":"",
                                     "validate":true,
                                     "showMessages":false,
-                                    "hideInitValidationError":true
+                                    "hideInitValidationError":true,
+                                    "sort":function(first, second) {
+                                        // Sort the dates in reverse so that the newest ones will be at the top.
+                                        return second.text.localeCompare(first.text);
+                                    }
                                 },
                                 "internalFillDate": {
                                     "type":"date",
@@ -1456,6 +1717,11 @@
                                                          }
                                                      ],
                                                      "horizontal":true
+                                                },
+                                                "events": {
+                                                    "ready" : function(field) {
+                                                        makeTextFieldReadOnly(this);                                                        
+                                                    }
                                                 }
                                             }
                                         }
@@ -1464,32 +1730,13 @@
                             },
                             "form":{
                                 "buttons":{
-                                    "localSave":{
-                                        "title": "Save JSON",
-                                        "fieldClass":"form-group btn-lg glyphicon-cloud-downloaded",
-                                        "click": function() {
-                                            var val = this.getValue();
-                                            if (this.isValid(true)) {
-                                                var myjson = JSON.stringify(val, null, "  ");
-                                                alert("Metadata Values: " + myjson);
-                                                var blob = new Blob([myjson], {type: "application/json"});
-                                                if (window.saveAs) {
-                                                    specFileName = val.limsSpecName + ".PS.json";
-                                                    window.saveAs(blob, specFileName);
-                                                }else{
-                                                    alert("saveAs not supported");
-                                                }
-                                            }else{
-                                                alert("Invalid - check that starred fields are not empty!");
-                                            }
-                                        }
-                                    }
+                                    "reset":{}
                                 }
                             },
                             "views":"bootstrap-create"
                         },
                         "data": {
-                            "formVersion": "2.0.3"
+                            "formVersion": "2.0.5"
                         }
                     });
                 });


### PR DESCRIPTION
Done as three commits to make changes easier to see.  The first commit renames JEM-2.0.4.html to JEM.html, and the second commit normalizes tabs into 4 spaces for consistency.

The [third](https://github.com/AllenInstitute/jem/commit/b3192e55fb0db4b13018dab171cecb84e93b618f) is the major feature commit.  Changes include:
- Removed old save button, added  Save and Load buttons that float at the top-right.
- Save checks validity before saving; If the form is invalid, it lists invalid fields and moves focus to the first.
- Load implemented. Select a file, it fills out the form.  Afterwards, does Save's validation behavior.
- Save/Load become disabled and have a special animated "Loading" state while they're processing.
- "Manual ROI" tree-selection now has a readonly textbox (and a helper function for future cases).
- "Blank Fill Date" is now a dropdown based on predefined values. We will need to keep this updated, but it will prevent incorrect dates.